### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -20,4 +20,4 @@ peek	KEYWORD2
 isEmpty	KEYWORD2
 isFull	KEYWORD2
 count	KEYWORD2
-setPrinter      KEYWORD2
+setPrinter	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords